### PR TITLE
Add 'Keep Screen On' UI/UX setting and idle-timer manager

### DIFF
--- a/FreeAPS/Sources/Application/AppServices.swift
+++ b/FreeAPS/Sources/Application/AppServices.swift
@@ -24,6 +24,7 @@ class AppServices: ObservableObject {
         _ = FreeAPSApp.resolver.resolve(HealthKitManager.self)!
         _ = FreeAPSApp.resolver.resolve(BluetoothStateManager.self)!
         _ = FreeAPSApp.resolver.resolve(LiveActivityBridge.self)!
+        _ = FreeAPSApp.resolver.resolve(ScreenIdleTimerManager.self)!
         settingsManager = resolver.resolve(SettingsManager.self)!
         carbsStorage = resolver.resolve(CarbsStorage.self)!
         calendarManager = resolver.resolve(CalendarManager.self)!

--- a/FreeAPS/Sources/Assemblies/ServiceAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/ServiceAssembly.swift
@@ -27,6 +27,7 @@ final class ServiceAssembly: Assembly {
         container.register(GarminManager.self) { r in BaseGarminManager(resolver: r) }
         container.register(ContactTrickManager.self) { r in BaseContactTrickManager(resolver: r) }
         container.register(LiveActivityBridge.self) { r in LiveActivityBridge(resolver: r) }
+        container.register(ScreenIdleTimerManager.self) { r in ScreenIdleTimerManager(resolver: r) }
         container.register(CoreDataStorageGlucoseSaver.self) { r in CoreDataStorageGlucoseSaver(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -61,6 +61,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var useTargetButton: Bool = false
     var alwaysUseColors: Bool = false
     var timeSettings: Bool = true
+    var keepScreenOn: Bool = false
     var disable15MinTrend: Bool = false
     var hidePredictions: Bool = false
     // Sounds
@@ -483,6 +484,10 @@ extension FreeAPSSettings: Decodable {
 
         if let timeSettings = try? container.decode(Bool.self, forKey: .timeSettings) {
             settings.timeSettings = timeSettings
+        }
+
+        if let keepScreenOn = try? container.decode(Bool.self, forKey: .keepScreenOn) {
+            settings.keepScreenOn = keepScreenOn
         }
 
         if let hypoSound = try? container.decode(String.self, forKey: .hypoSound) {

--- a/FreeAPS/Sources/Modules/UIUX/UIUXStateModel.swift
+++ b/FreeAPS/Sources/Modules/UIUX/UIUXStateModel.swift
@@ -32,6 +32,7 @@ extension UIUX {
         @Published var useCarbBars: Bool = false
         @Published var ai: Bool = true
         @Published var skipSave: Bool = false
+        @Published var keepScreenOn: Bool = false
 
         var units: GlucoseUnits = .mmolL
 
@@ -65,6 +66,7 @@ extension UIUX {
             subscribeSetting(\.useCarbBars, on: $useCarbBars) { useCarbBars = $0 }
             subscribeSetting(\.ai, on: $ai) { ai = $0 }
             subscribeSetting(\.skipSave, on: $skipSave) { skipSave = $0 }
+            subscribeSetting(\.keepScreenOn, on: $keepScreenOn) { keepScreenOn = $0 }
 
             subscribeSetting(\.low, on: $low, initial: {
                 let value = max(min($0, 90), 40)

--- a/FreeAPS/Sources/Modules/UIUX/View/UIUXRootView.swift
+++ b/FreeAPS/Sources/Modules/UIUX/View/UIUXRootView.swift
@@ -64,6 +64,10 @@ extension UIUX {
                     }
 
                 Section {
+                    Toggle("Keep Screen On While iAPS Is Open", isOn: $state.keepScreenOn)
+                } header: { Text("Screen") }
+
+                Section {
                     HStack {
                         Text("Low")
                         Spacer()

--- a/FreeAPS/Sources/Services/ScreenIdleTimerManager.swift
+++ b/FreeAPS/Sources/Services/ScreenIdleTimerManager.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+final class ScreenIdleTimerManager: Injectable, SettingsObserver {
+    @Injected() private var settingsManager: SettingsManager!
+    @Injected() private var broadcaster: Broadcaster!
+
+    private var keepScreenOn: Bool = false
+
+    init(resolver: Resolver) {
+        injectServices(resolver)
+        keepScreenOn = settingsManager.settings.keepScreenOn
+        broadcaster.register(SettingsObserver.self, observer: self)
+
+        Foundation.NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            self.updateIdleTimer()
+        }
+
+        Foundation.NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            self.updateIdleTimer()
+        }
+
+        updateIdleTimer()
+    }
+
+    func settingsDidChange(_ newSettings: FreeAPSSettings) {
+        keepScreenOn = newSettings.keepScreenOn
+        updateIdleTimer()
+    }
+
+    private func updateIdleTimer() {
+        let shouldDisable = keepScreenOn && UIApplication.shared.applicationState == .active
+        DispatchQueue.main.async {
+            UIApplication.shared.isIdleTimerDisabled = shouldDisable
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a user-facing toggle to prevent the device from sleeping while iAPS is open to improve usability during monitoring. 
- Persist the preference so the choice survives app restarts via the app settings storage. 
- Ensure the system idle timer reflects the setting when the app moves between active/background states. 
- Isolate idle-timer logic in a service to keep UI and application lifecycle code clean. 

### Description
- Added a new setting `keepScreenOn` to `FreeAPSSettings` and decoded it in the settings initializer. 
- Exposed `keepScreenOn` in the UI state by adding `@Published var keepScreenOn` to `UIUX.StateModel` and subscribing it to the persisted setting via `subscribeSetting`. 
- Added a `Toggle` labeled "Keep Screen On While iAPS Is Open" to the UI at `UIUXRootView`. 
- Implemented `ScreenIdleTimerManager` service that implements `SettingsObserver` and updates `UIApplication.shared.isIdleTimerDisabled` on app lifecycle notifications, and registered/resolved it in `ServiceAssembly` and `AppServices`. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952170f94c083288e7ab50146a4670f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a user-configurable option to prevent the device from sleeping while the app is active and wires it through settings, UI, and app lifecycle.
> 
> - Adds `keepScreenOn` to `FreeAPSSettings` with decoding and exposes it via `UIUX.StateModel` (published + `subscribeSetting`)
> - Adds a toggle in `UIUXRootView` under a new "Screen" section to control `keepScreenOn`
> - Implements `ScreenIdleTimerManager` that observes settings and app lifecycle notifications to set `UIApplication.shared.isIdleTimerDisabled` when the app is active
> - Registers the manager in `ServiceAssembly` and resolves it in `AppServices` so it initializes on app launch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f053ccd8c9e65973eb62f571ee91220d087afd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->